### PR TITLE
Fix BlueZ D-Bus connection lifecycle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.12"
 dependencies = [
     "bleak>=3.0.1",
     "bleakheart>=0.2.0",
-    "dbus-next>=0.2.3",
+    "dbus-fast>=3.0.2",
     "loguru>=0.7.3",
     "pydantic>=2.13.1",
     "pyftms>=0.4.15",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,4 +56,4 @@ ignore = [
 ]
 
 [tool.uv.sources]
-pyftms = { git = "https://github.com/luigi311/python-pyftms", branch = "dont_fail_on_gatt_read" }
+pyftms = { git = "https://github.com/luigi311/python-pyftms", rev = "7c828fcf8b47f4ec917edec8b9a1585db4e35352" }

--- a/src/bleaksport/linux_bluez.py
+++ b/src/bleaksport/linux_bluez.py
@@ -39,6 +39,7 @@ async def bluez_disconnect(mac: str) -> None:
             text = reply.body[0] if reply.body else error_name
             raise DBusError(error_name, text, reply=reply)
     finally:
-        bus.disconnect()
+        with contextlib.suppress(Exception):
+            bus.disconnect()
         with contextlib.suppress(Exception):
             await bus.wait_for_disconnect()

--- a/src/bleaksport/linux_bluez.py
+++ b/src/bleaksport/linux_bluez.py
@@ -1,29 +1,44 @@
 import contextlib
 import platform
-import subprocess
 
-from dbus_next import BusType
-from dbus_next.aio import MessageBus
-from loguru import logger
+from dbus_fast import BusType, DBusError, Message, MessageType
+from dbus_fast.aio import MessageBus
 
 
 def _is_linux() -> bool:
     return platform.system().lower() == "linux"
 
+
 def mac_to_path(mac: str, adapter: str = "hci0") -> str:
     return f"/org/bluez/{adapter}/dev_{mac.replace(':', '_').upper()}"
+
 
 async def bluez_disconnect(mac: str) -> None:
     """Politely ask BlueZ to disconnect the device (does not clear bonding)."""
     if not _is_linux():
         return
 
-    bus = await MessageBus(bus_type=BusType.SYSTEM).connect()
+    # MessageBus opens its socket during construction, before connect() is
+    # awaited, so it must be owned before entering the try block.  Always wait
+    # for finalization so repeated reconnect attempts cannot accumulate system
+    # bus connections or selector readers.
+    bus = MessageBus(bus_type=BusType.SYSTEM)
+    try:
+        await bus.connect()
 
-    path = mac_to_path(mac)
-    introspection = await bus.introspect("org.bluez", path)
-    obj = bus.get_proxy_object("org.bluez", path, introspection)
-
-    device = obj.get_interface("org.bluez.Device1")
-
-    await device.call_disconnect()
+        reply = await bus.call(
+            Message(
+                destination="org.bluez",
+                path=mac_to_path(mac),
+                interface="org.bluez.Device1",
+                member="Disconnect",
+            )
+        )
+        if reply.message_type == MessageType.ERROR:
+            error_name = reply.error_name or "org.bluez.Error.Failed"
+            text = reply.body[0] if reply.body else error_name
+            raise DBusError(error_name, text, reply=reply)
+    finally:
+        bus.disconnect()
+        with contextlib.suppress(Exception):
+            await bus.wait_for_disconnect()

--- a/src/bleaksport/mux_base.py
+++ b/src/bleaksport/mux_base.py
@@ -122,17 +122,21 @@ class MuxBase:
     async def _run_device(self, addr: str, roles: set[str]) -> None:
         while not self._stop_evt.is_set():
             client: BleakClient | None = None
+            session: Any = None
+            needs_bluez_fallback = False
             try:
                 # Connect + start session under the BLE lock
                 async with self._ble_lock:
                     client = BleakClient(addr, disconnected_callback=lambda _c: None)
                     await client.connect()
+                    # Register resources as soon as they exist. If session setup
+                    # fails or the task is cancelled, finally can still close the
+                    # Bleak client's per-connection D-Bus bus.
+                    self._clients[addr] = client
 
                     session = await self._make_session(client)
+                    self._sessions[addr] = session
                     await self._start_session(session, client)
-
-                self._clients[addr] = client
-                self._sessions[addr] = session
 
                 # Best-effort service discovery for role presence
                 try:
@@ -167,49 +171,50 @@ class MuxBase:
             except BleakError as e:
                 msg = str(e)
                 if INPROGRESS_RE.search(msg):
+                    needs_bluez_fallback = True
                     await asyncio.sleep(1.5)
             except Exception as e:
                 self._on_status(f"Unexpected error @ {addr}: {type(e).__name__}: {e}")
             finally:
-                # Clean shutdown (serialize under lock; then tell BlueZ)
+                # Clean shutdown. The direct BlueZ call is only a fallback for
+                # an InProgress state or a Bleak disconnect that did not finish.
                 logger.debug(f"Cleaning up {addr} device")
 
                 with contextlib.suppress(Exception):
                     self._on_link(addr, False, {})
                     logger.debug("on_link nulled")
 
-                try:
-                    if addr in self._sessions:
+                session_to_stop = self._sessions.pop(addr, None) or session
+                client_to_disconnect = self._clients.pop(addr, None) or client
+
+                async with self._ble_lock:
+                    if session_to_stop is not None and client_to_disconnect is not None:
                         try:
                             logger.debug(f"Stopping sessions for {addr}")
-                            await self._stop_session(
-                                self._sessions[addr], self._clients.get(addr)
-                            )
+                            await self._stop_session(session_to_stop, client_to_disconnect)
                             logger.debug(f"Session for {addr} stopped")
                         except Exception as e:
                             logger.warning(f"Stopping sessions failed for {addr} {e}")
 
-                        self._sessions.pop(addr, None)
-
-                    if addr in self._clients:
+                    if client_to_disconnect is not None:
                         try:
                             logger.debug(f"Disconnecting {addr}")
-                            await self._clients[addr].disconnect()
+                            await client_to_disconnect.disconnect()
                             logger.debug(f"Disconnected {addr} successfully")
                         except Exception as e:
+                            needs_bluez_fallback = True
                             logger.warning(f"Disconnect failed for {addr} {e}")
 
-                        self._clients.pop(addr, None)
+                        with contextlib.suppress(Exception):
+                            needs_bluez_fallback |= bool(client_to_disconnect.is_connected)
 
+                if needs_bluez_fallback:
                     try:
-                        logger.debug(f"Bluez disconnecting {addr}")
+                        logger.debug(f"BlueZ fallback disconnecting {addr}")
                         await bluez_disconnect(addr)
-                        logger.debug(f"Bluez disconnected {addr} successfully")
+                        logger.debug(f"BlueZ fallback disconnected {addr} successfully")
                     except Exception as e:
-                        logger.warning(f"Bluez disconnect failed for {addr} {e}")
-
-                except Exception as e:
-                    logger.warning(f"Cleaning up sensor failed {addr} {e}")
+                        logger.warning(f"BlueZ fallback disconnect failed for {addr} {e}")
 
                 if not self._stop_evt.is_set():
                     await asyncio.sleep(self._reconnect_backoff_s)

--- a/src/bleaksport/mux_base.py
+++ b/src/bleaksport/mux_base.py
@@ -173,6 +173,8 @@ class MuxBase:
                 if INPROGRESS_RE.search(msg):
                     needs_bluez_fallback = True
                     await asyncio.sleep(1.5)
+                else:
+                    self._on_status(f"Bleak error @ {addr}: {type(e).__name__}: {e}")
             except Exception as e:
                 self._on_status(f"Unexpected error @ {addr}: {type(e).__name__}: {e}")
             finally:

--- a/src/bleaksport/trainer.py
+++ b/src/bleaksport/trainer.py
@@ -425,9 +425,10 @@ class TrainerMux:
         self._last = None
 
         disconnected = True
-        # pyftms only calls BleakClient.disconnect() while is_connected is
-        # true. Capture the client first so a disconnect callback deleting
-        # machine._cli cannot prevent closure of Bleak's D-Bus connection.
+        # pyftms commit 7c828fc exposes only disconnect(), which skips cleanup
+        # once is_connected is false and whose disconnect callback deletes
+        # _cli. The dependency is pinned to that commit, so capture its client
+        # first and ensure Bleak's per-connection D-Bus bus is closed.
         client = getattr(m, "_cli", None)
         async with self._ble_lock:
             try:

--- a/src/bleaksport/trainer.py
+++ b/src/bleaksport/trainer.py
@@ -116,9 +116,9 @@ class TrainerMux:
                 await self._task
             self._task = None
 
-        await self._disconnect()
-        with contextlib.suppress(Exception):
-            if self.addr:
+        disconnected = await self._disconnect()
+        if not disconnected and self.addr:
+            with contextlib.suppress(Exception):
                 await bluez_disconnect(self.addr)
 
     async def wait_connected(self, timeout_s: float = 20.0) -> None:
@@ -304,17 +304,19 @@ class TrainerMux:
         logger.debug("TrainerMux run loop starting")
         # Mimic MuxBase behavior: loop with backoff, clean disconnect, robust finally.
         while not self._stop_evt.is_set():
+            needs_bluez_fallback = False
             try:
                 await self._connect_and_stream()
 
                 # Stay alive until stop requested or machine disappears.
-                while not self._stop_evt.is_set() and self._machine is not None:
+                while not self._stop_evt.is_set() and self.is_connected:
                     await asyncio.sleep(1.0)
 
             except asyncio.CancelledError:
                 return
             except Exception as e:
                 if INPROGRESS_RE.search(str(e)):
+                    needs_bluez_fallback = True
                     logger.warning("TrainerMux ble connection in progress, will retry")
                 else:
                     msg = f"TrainerMux error @ {self.addr}: {type(e).__name__}: {e}"
@@ -324,9 +326,10 @@ class TrainerMux:
                 # Mirror MuxBase: always emit disconnected and try to clean up BlueZ state.
                 with contextlib.suppress(Exception):
                     self._on_link(self.addr or "-", False, {})
-                await self._disconnect()
-                with contextlib.suppress(Exception):
-                    if self.addr:
+                disconnected = await self._disconnect()
+                needs_bluez_fallback |= not disconnected
+                if needs_bluez_fallback and self.addr:
+                    with contextlib.suppress(Exception):
                         await bluez_disconnect(self.addr)
 
             if not self._stop_evt.is_set():
@@ -378,9 +381,17 @@ class TrainerMux:
                 logger.error(msg)
                 raise RuntimeError(msg)
 
-            await machine.connect()
+            # Own the machine before awaiting setup. pyftms can establish its
+            # Bleak connection and then fail while reading features or starting
+            # notifications; assigning early makes that partial client reachable
+            # by _disconnect().
+            self._machine = machine
 
-        self._machine = machine
+            def _on_machine_disconnect(_machine: FitnessMachine) -> None:
+                self._connected_evt.clear()
+
+            machine.set_disconnect_callback(_on_machine_disconnect)
+            await machine.connect()
 
         logger.debug(f"TrainerMux connected to machine: {machine}")
         logger.debug(f"Supported properties: {machine.supported_properties}")
@@ -403,20 +414,36 @@ class TrainerMux:
         logger.debug(f"Setting startup resistance level: {self.starting_resistance}")
         await self.set_target_resistance(self.starting_resistance)
 
-
-    async def _disconnect(self) -> None:
+    async def _disconnect(self) -> bool:
         m = self._machine
         self._machine = None
         self._connected_evt.clear()
         if not m:
-            return
+            return True
 
         # Wipe sticky cache
         self._last = None
 
+        disconnected = True
+        # pyftms only calls BleakClient.disconnect() while is_connected is
+        # true. Capture the client first so a disconnect callback deleting
+        # machine._cli cannot prevent closure of Bleak's D-Bus connection.
+        client = getattr(m, "_cli", None)
         async with self._ble_lock:
-            with contextlib.suppress(Exception):
+            try:
                 await m.disconnect()
+            except Exception as e:
+                disconnected = False
+                logger.warning(f"Trainer disconnect failed: {e}")
+
+            if client is not None:
+                try:
+                    await client.disconnect()
+                except Exception as e:
+                    disconnected = False
+                    logger.warning(f"Trainer Bleak client disconnect failed: {e}")
+
+        return disconnected
 
     def _merge_last(self, new: TrainerSample) -> TrainerSample:
         prev = self._last

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,221 @@
+# ruff: noqa: ANN001, ANN201, ANN202, ANN204, ARG002, D101, D102, I001, PT009, PT027, SIM117, SLF001
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from dbus_next import MessageType
+from pyftms import ResultCode
+
+from bleaksport import linux_bluez
+from bleaksport.mux_base import MuxBase
+from bleaksport.trainer import TrainerMux
+
+
+class _FakeBus:
+    def __init__(self, *, fail_connect=False, fail_call=False):
+        self.fail_connect = fail_connect
+        self.fail_call = fail_call
+        self.disconnect_called = False
+        self.wait_called = False
+
+    async def connect(self):
+        if self.fail_connect:
+            msg = "connect failed"
+            raise RuntimeError(msg)
+        return self
+
+    async def call(self, _message):
+        if self.fail_call:
+            msg = "method call failed"
+            raise RuntimeError(msg)
+        return type(
+            "Reply",
+            (),
+            {"message_type": MessageType.METHOD_RETURN, "body": [], "error_name": None},
+        )()
+
+    def disconnect(self):
+        self.disconnect_called = True
+
+    async def wait_for_disconnect(self):
+        self.wait_called = True
+
+
+class BlueZDisconnectTests(unittest.IsolatedAsyncioTestCase):
+    async def test_bus_is_closed_after_success(self):
+        bus = _FakeBus()
+        with (
+            patch.object(linux_bluez, "_is_linux", return_value=True),
+            patch.object(linux_bluez, "MessageBus", return_value=bus),
+        ):
+            await linux_bluez.bluez_disconnect("AA:BB:CC:DD:EE:FF")
+
+        self.assertTrue(bus.disconnect_called)
+        self.assertTrue(bus.wait_called)
+
+    async def test_bus_is_closed_when_connect_fails(self):
+        bus = _FakeBus(fail_connect=True)
+        with (
+            patch.object(linux_bluez, "_is_linux", return_value=True),
+            patch.object(linux_bluez, "MessageBus", return_value=bus),
+            self.assertRaises(RuntimeError),
+        ):
+            await linux_bluez.bluez_disconnect("AA:BB:CC:DD:EE:FF")
+
+        self.assertTrue(bus.disconnect_called)
+        self.assertTrue(bus.wait_called)
+
+    async def test_bus_is_closed_when_method_call_fails(self):
+        bus = _FakeBus(fail_call=True)
+        with (
+            patch.object(linux_bluez, "_is_linux", return_value=True),
+            patch.object(linux_bluez, "MessageBus", return_value=bus),
+            self.assertRaises(RuntimeError),
+        ):
+            await linux_bluez.bluez_disconnect("AA:BB:CC:DD:EE:FF")
+
+        self.assertTrue(bus.disconnect_called)
+        self.assertTrue(bus.wait_called)
+
+
+class _FakeBleakClient:
+    def __init__(self, *, disconnect_error=False):
+        self.is_connected = False
+        self.disconnect_error = disconnect_error
+        self.disconnect_calls = 0
+        self.services = None
+
+    async def connect(self):
+        self.is_connected = True
+
+    async def disconnect(self):
+        self.disconnect_calls += 1
+        if self.disconnect_error:
+            msg = "disconnect failed"
+            raise RuntimeError(msg)
+        self.is_connected = False
+
+
+class _LifecycleMux(MuxBase):
+    def __init__(self, *, start_error=None):
+        super().__init__(roles_to_addrs={"sensor": "AA:BB"}, on_status=lambda _msg: None)
+        self.start_error = start_error
+        self.session_stopped = False
+
+    async def _make_session(self, client):
+        return object()
+
+    async def _start_session(self, session, client):
+        self._stop_evt.set()
+        client.is_connected = False
+        if self.start_error:
+            raise self.start_error
+
+    async def _stop_session(self, session, client):
+        self.session_stopped = True
+
+
+class MuxLifecycleTests(unittest.IsolatedAsyncioTestCase):
+    async def test_partial_session_setup_still_disconnects_client(self):
+        client = _FakeBleakClient()
+        mux = _LifecycleMux(start_error=RuntimeError("session setup failed"))
+        fallback = AsyncMock()
+
+        with (
+            patch("bleaksport.mux_base.BleakClient", return_value=client),
+            patch("bleaksport.mux_base.bluez_disconnect", fallback),
+        ):
+            await mux._run_device("AA:BB", {"sensor"})
+
+        self.assertTrue(mux.session_stopped)
+        self.assertEqual(client.disconnect_calls, 1)
+        self.assertEqual(mux._clients, {})
+        self.assertEqual(mux._sessions, {})
+        fallback.assert_not_awaited()
+
+    async def test_failed_bleak_disconnect_uses_bluez_fallback(self):
+        client = _FakeBleakClient(disconnect_error=True)
+        mux = _LifecycleMux()
+        fallback = AsyncMock()
+
+        with (
+            patch("bleaksport.mux_base.BleakClient", return_value=client),
+            patch("bleaksport.mux_base.bluez_disconnect", fallback),
+        ):
+            await mux._run_device("AA:BB", {"sensor"})
+
+        fallback.assert_awaited_once_with("AA:BB")
+
+
+class _TrainerBleakClient:
+    def __init__(self):
+        self.disconnect_calls = 0
+
+    async def disconnect(self):
+        self.disconnect_calls += 1
+
+
+class _FakeMachine:
+    def __init__(self, *, connect_error=None):
+        self.connect_error = connect_error
+        self._cli = _TrainerBleakClient()
+        self.disconnect_calls = 0
+        self.disconnect_callback = None
+        self.machine_type = object()
+        self.supported_properties = []
+        self.supported_settings = []
+        self.supported_ranges = {}
+        self.target_resistance = None
+
+    def set_disconnect_callback(self, callback):
+        self.disconnect_callback = callback
+
+    async def connect(self):
+        if self.connect_error:
+            raise self.connect_error
+
+    async def disconnect(self):
+        self.disconnect_calls += 1
+
+    async def start_resume(self):
+        return ResultCode.SUCCESS
+
+    async def set_target_resistance(self, level):
+        self.target_resistance = level
+        return ResultCode.SUCCESS
+
+
+class _Device:
+    address = "AA:BB"
+
+
+class TrainerLifecycleTests(unittest.IsolatedAsyncioTestCase):
+    async def test_partial_machine_setup_remains_owned_for_cleanup(self):
+        machine = _FakeMachine(connect_error=RuntimeError("feature read failed"))
+        mux = TrainerMux(addr=_Device(), machine_type=object())
+
+        with patch("bleaksport.trainer.get_client", return_value=machine):
+            with self.assertRaises(RuntimeError):
+                await mux._connect_and_stream()
+
+        self.assertIs(mux._machine, machine)
+        self.assertTrue(await mux._disconnect())
+        self.assertEqual(machine.disconnect_calls, 1)
+        self.assertEqual(machine._cli.disconnect_calls, 1)
+
+    async def test_machine_disconnect_callback_clears_link_state(self):
+        machine = _FakeMachine()
+        mux = TrainerMux(addr=_Device(), machine_type=object())
+
+        with patch("bleaksport.trainer.get_client", return_value=machine):
+            await mux._connect_and_stream()
+
+        self.assertTrue(mux.is_connected)
+        machine.disconnect_callback(machine)
+        self.assertFalse(mux.is_connected)
+        await mux._disconnect()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -4,7 +4,8 @@ import asyncio
 import unittest
 from unittest.mock import AsyncMock, patch
 
-from dbus_next import MessageType
+from bleak import BleakError
+from dbus_fast import DBusError, Message, MessageType
 from pyftms import ResultCode
 
 from bleaksport import linux_bluez
@@ -13,9 +14,18 @@ from bleaksport.trainer import TrainerMux
 
 
 class _FakeBus:
-    def __init__(self, *, fail_connect=False, fail_call=False):
+    def __init__(
+        self,
+        *,
+        fail_connect=False,
+        fail_call=False,
+        error_reply=False,
+        fail_disconnect=False,
+    ):
         self.fail_connect = fail_connect
         self.fail_call = fail_call
+        self.error_reply = error_reply
+        self.fail_disconnect = fail_disconnect
         self.disconnect_called = False
         self.wait_called = False
 
@@ -29,14 +39,24 @@ class _FakeBus:
         if self.fail_call:
             msg = "method call failed"
             raise RuntimeError(msg)
-        return type(
-            "Reply",
-            (),
-            {"message_type": MessageType.METHOD_RETURN, "body": [], "error_name": None},
-        )()
+        if self.error_reply:
+            return Message(
+                message_type=MessageType.ERROR,
+                reply_serial=_message.serial or 1,
+                error_name="org.bluez.Error.Failed",
+                signature="s",
+                body=["BlueZ rejected disconnect"],
+            )
+        return Message(
+            message_type=MessageType.METHOD_RETURN,
+            reply_serial=_message.serial or 1,
+        )
 
     def disconnect(self):
         self.disconnect_called = True
+        if self.fail_disconnect:
+            msg = "disconnect cleanup failed"
+            raise RuntimeError(msg)
 
     async def wait_for_disconnect(self):
         self.wait_called = True
@@ -78,15 +98,42 @@ class BlueZDisconnectTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(bus.disconnect_called)
         self.assertTrue(bus.wait_called)
 
+    async def test_bluez_error_reply_raises_dbus_error_and_closes_bus(self):
+        bus = _FakeBus(error_reply=True)
+        with (
+            patch.object(linux_bluez, "_is_linux", return_value=True),
+            patch.object(linux_bluez, "MessageBus", return_value=bus),
+            self.assertRaises(DBusError),
+        ):
+            await linux_bluez.bluez_disconnect("AA:BB:CC:DD:EE:FF")
+
+        self.assertTrue(bus.disconnect_called)
+        self.assertTrue(bus.wait_called)
+
+    async def test_disconnect_cleanup_error_does_not_replace_original_error(self):
+        bus = _FakeBus(fail_call=True, fail_disconnect=True)
+        with (
+            patch.object(linux_bluez, "_is_linux", return_value=True),
+            patch.object(linux_bluez, "MessageBus", return_value=bus),
+            self.assertRaisesRegex(RuntimeError, "method call failed"),
+        ):
+            await linux_bluez.bluez_disconnect("AA:BB:CC:DD:EE:FF")
+
+        self.assertTrue(bus.disconnect_called)
+        self.assertTrue(bus.wait_called)
+
 
 class _FakeBleakClient:
-    def __init__(self, *, disconnect_error=False):
+    def __init__(self, *, connect_error=None, disconnect_error=False):
+        self.connect_error = connect_error
         self.is_connected = False
         self.disconnect_error = disconnect_error
         self.disconnect_calls = 0
         self.services = None
 
     async def connect(self):
+        if self.connect_error:
+            raise self.connect_error
         self.is_connected = True
 
     async def disconnect(self):
@@ -99,7 +146,14 @@ class _FakeBleakClient:
 
 class _LifecycleMux(MuxBase):
     def __init__(self, *, start_error=None):
-        super().__init__(roles_to_addrs={"sensor": "AA:BB"}, on_status=lambda _msg: None)
+        self.statuses = []
+        self.status_event = asyncio.Event()
+
+        def on_status(message):
+            self.statuses.append(message)
+            self.status_event.set()
+
+        super().__init__(roles_to_addrs={"sensor": "AA:BB"}, on_status=on_status)
         self.start_error = start_error
         self.session_stopped = False
 
@@ -117,6 +171,22 @@ class _LifecycleMux(MuxBase):
 
 
 class MuxLifecycleTests(unittest.IsolatedAsyncioTestCase):
+    async def test_non_inprogress_bleak_error_reports_device_context(self):
+        client = _FakeBleakClient(connect_error=BleakError("connection rejected"))
+        mux = _LifecycleMux()
+
+        with patch("bleaksport.mux_base.BleakClient", return_value=client):
+            task = asyncio.create_task(mux._run_device("AA:BB", {"sensor"}))
+            await asyncio.wait_for(mux.status_event.wait(), timeout=1)
+            task.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await task
+
+        self.assertEqual(
+            mux.statuses,
+            ["Bleak error @ AA:BB: BleakError: connection rejected"],
+        )
+
     async def test_partial_session_setup_still_disconnects_client(self):
         client = _FakeBleakClient()
         mux = _LifecycleMux(start_error=RuntimeError("session setup failed"))

--- a/uv.lock
+++ b/uv.lock
@@ -97,7 +97,7 @@ requires-dist = [
     { name = "dbus-fast", specifier = ">=3.0.2" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "pydantic", specifier = ">=2.13.1" },
-    { name = "pyftms", git = "https://github.com/luigi311/python-pyftms?branch=dont_fail_on_gatt_read" },
+    { name = "pyftms", git = "https://github.com/luigi311/python-pyftms?rev=7c828fcf8b47f4ec917edec8b9a1585db4e35352" },
 ]
 
 [package.metadata.requires-dev]
@@ -267,7 +267,7 @@ wheels = [
 [[package]]
 name = "pyftms"
 version = "0.4.15"
-source = { git = "https://github.com/luigi311/python-pyftms?branch=dont_fail_on_gatt_read#7c828fcf8b47f4ec917edec8b9a1585db4e35352" }
+source = { git = "https://github.com/luigi311/python-pyftms?rev=7c828fcf8b47f4ec917edec8b9a1585db4e35352#7c828fcf8b47f4ec917edec8b9a1585db4e35352" }
 dependencies = [
     { name = "bleak" },
     { name = "bleak-retry-connector" },

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ source = { editable = "." }
 dependencies = [
     { name = "bleak" },
     { name = "bleakheart" },
-    { name = "dbus-next" },
+    { name = "dbus-fast" },
     { name = "loguru" },
     { name = "pydantic" },
     { name = "pyftms" },
@@ -92,9 +92,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bleak", specifier = "==3.0.1" },
+    { name = "bleak", specifier = ">=3.0.1" },
     { name = "bleakheart", specifier = ">=0.2.0" },
-    { name = "dbus-next", specifier = ">=0.2.3" },
+    { name = "dbus-fast", specifier = ">=3.0.2" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "pydantic", specifier = ">=2.13.1" },
     { name = "pyftms", git = "https://github.com/luigi311/python-pyftms?branch=dont_fail_on_gatt_read" },
@@ -138,32 +138,27 @@ version = "4.0.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5f/cd/402b0e524bdf37d8b1d22b1d926c538bf1d2eedf115ea1d401c6c08a7d81/dbus_fast-4.0.4.tar.gz", hash = "sha256:43137f0b73a7adbf7d5c0e9eb9d8d34df9e6e0aeafade2166e641c52dfe0a853", size = 75260, upload-time = "2026-04-02T04:41:16.47Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/a5/3d68c39b6c157b4542a154030d3d75123124190420d3c2d9733e554cc131/dbus_fast-4.0.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:139b462190f7421e55fec421108f824425a559b3d9a5e0b15421e68275735bad", size = 680584, upload-time = "2026-04-02T04:50:00.085Z" },
     { url = "https://files.pythonhosted.org/packages/a8/cf/86b4b7057d11af1549135234612e40401c69f339551a1c0cd011439a6b8b/dbus_fast-4.0.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:00a3db08cf1d98bbedfb73467b774fd49adcf83935b8a92f6c552ce78d93491f", size = 792151, upload-time = "2026-04-02T04:50:02.014Z" },
     { url = "https://files.pythonhosted.org/packages/95/e5/056a5845b19202336caed7d3b18896c75ec059b68c16f4ded71749c9e0a2/dbus_fast-4.0.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74183b4ef4cc79a9cd1a46e006c19d00ce9abc7d99d36e6adcd094f414446d38", size = 844081, upload-time = "2026-04-02T04:50:04.007Z" },
     { url = "https://files.pythonhosted.org/packages/25/03/aa1ef750da5f4cfd15eac9892c05ff95b6380cdc44d5bb63b8379c63e81f/dbus_fast-4.0.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:003f042b1299ebac900d6ee30e8ab2a29988937f56792894da7b5d39a26b1f5f", size = 799573, upload-time = "2026-04-02T04:50:05.58Z" },
     { url = "https://files.pythonhosted.org/packages/22/0c/2338ca2a51eca2392eddd1c1854a5127a8deb705a65a1fc66dc49d1a5557/dbus_fast-4.0.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:87be8a41330481c3d3a5e30af10ec713e4f08fe0d6c36f5a401eaef7b5526417", size = 852067, upload-time = "2026-04-02T04:50:07.348Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ca/b16e55d6cca2105229d009b566187b1d96703976dcf4b4a3377f6bb542dc/dbus_fast-4.0.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:728bc8a02302c6677a42da2b037580755b29c8fccd5c0866acc529053b2d374d", size = 676240, upload-time = "2026-04-02T04:50:08.856Z" },
     { url = "https://files.pythonhosted.org/packages/e9/3e/d8b733cca2dc03746496c2ea799125414cd875830a8cb384f1395ab6993d/dbus_fast-4.0.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fe60ce3a97e265a3ad117b7f40fc8c08357781b1a2ed3e853f29f9e35d24af7", size = 790985, upload-time = "2026-04-02T04:50:10.742Z" },
     { url = "https://files.pythonhosted.org/packages/aa/85/ec643d891f4bb38347172ca99e4fbeaa55b9a5c3a744bac42c3074893482/dbus_fast-4.0.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:982235dabb7e7187df4c2c299d95a6232aebc95c8c906496f630265a10bfdf95", size = 840552, upload-time = "2026-04-02T04:50:12.43Z" },
     { url = "https://files.pythonhosted.org/packages/83/d5/50fb58f11387ab165f4ad010db9f5434aa386b8308467b5d968a10d09864/dbus_fast-4.0.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:33c0168e0e65ed2d0fa91682773cc893472e3d71a5e085ee082e6484c2d29f4a", size = 797179, upload-time = "2026-04-02T04:50:14.435Z" },
     { url = "https://files.pythonhosted.org/packages/ca/25/dd83b280a4a405f7e1558951492714935e0c1601724d35a0db970afd0ad0/dbus_fast-4.0.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:069df5d46390299d7fccfc0e704af504a8b75794c2c3bc0246b6db0db1f245b0", size = 849052, upload-time = "2026-04-02T04:50:16.563Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/d9/9af5a38ab9d04054b9e466332ed92d921da7a8166146a2c9e95936f7bed5/dbus_fast-4.0.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3564c8a756903a6edf01ceb4dd4927354f03b40a28f000e2b896f02a784e9301", size = 683781, upload-time = "2026-04-02T04:50:18.781Z" },
     { url = "https://files.pythonhosted.org/packages/e0/ec/22c8904c1f3ecaee2012dfb1eb05d0481bedfaea80f27eab66d120f80b37/dbus_fast-4.0.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c3a8c07d672b1656a9c7cbdc9a85f493602f72fce8e7f9d97c5e972fa22a684", size = 804433, upload-time = "2026-04-02T04:50:20.747Z" },
     { url = "https://files.pythonhosted.org/packages/1d/e9/4b3eabb25886f33218b96c7a0e2cd684a50932e00d951aae0181075d5217/dbus_fast-4.0.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5512b9901ba600f1efdae2555ea18da2b67a46e5c24e397edb38ecbbde4aa43f", size = 846351, upload-time = "2026-04-02T04:50:22.9Z" },
     { url = "https://files.pythonhosted.org/packages/4b/bc/a8330670389de2b69e7fb43b20ad08f0c3614f7d4a3a6cc9cbfcf72555fb/dbus_fast-4.0.4-cp314-cp314-manylinux_2_41_x86_64.whl", hash = "sha256:36f86ba826f05c4d238c9198ae962f90a9cd27ffacd3a4a988166b3d06c699ca", size = 844513, upload-time = "2026-04-02T04:41:15.087Z" },
     { url = "https://files.pythonhosted.org/packages/ea/54/11a6f5cd13e67d30056651a6324b620f621a6980c1fc872fed3d1acdd1a0/dbus_fast-4.0.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:df0f88a9c1c9f9365627fbfb3dcae3589a12fdc82594945832cb24d9a62674d1", size = 811253, upload-time = "2026-04-02T04:50:24.615Z" },
     { url = "https://files.pythonhosted.org/packages/f2/bd/30c204bdd0a779cf46f3a4faad5cb62c9bd42a22ebcb89caffecf488493d/dbus_fast-4.0.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4c6c8722e829b8e750fd6db2906b298d3bcfc32d8cdf766e50ba474ef48bf2af", size = 853231, upload-time = "2026-04-02T04:50:26.239Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/0e/10248b27cfb5009bc11010d95abdee4e881ff8081e2174642ce2a1d5ecaf/dbus_fast-4.0.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8a515e8de0e5971e64a3f49fad2e536b6d2167a9f489e597baf7c802cfb7eef3", size = 1342087, upload-time = "2026-04-02T04:50:28.305Z" },
     { url = "https://files.pythonhosted.org/packages/74/73/af9794109638e38d59ea1ecbf18c4dea25f802debffc285504a6ebc81b2c/dbus_fast-4.0.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad5240c29ec631f9610e03a6bbf4f4c22274e04ea8791e8401542cd6cdbd7b28", size = 1534429, upload-time = "2026-04-02T04:50:29.998Z" },
     { url = "https://files.pythonhosted.org/packages/82/3d/a033cc655a3a32ee145f575cd05066cf5bed71e24238947d77fb9597c905/dbus_fast-4.0.4-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5843c3e543ac1d48cafff67394ada9e568f20d122b44408e378ae43402b785ca", size = 1610602, upload-time = "2026-04-02T04:50:32.146Z" },
     { url = "https://files.pythonhosted.org/packages/4a/46/2834b825da3f6ef206f5bc55363bc8751addcfc03fa34c639f72006f6a3e/dbus_fast-4.0.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7ebb845f2e15ef19f4a99cb879dfbcb1c7028a97d5aaba93b36f65cfd938a022", size = 1550136, upload-time = "2026-04-02T04:50:34.311Z" },
     { url = "https://files.pythonhosted.org/packages/9e/01/894b2f6954d12c5c527232906d67272b59f0f12f386cd2d394d5e5eac7fc/dbus_fast-4.0.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:698fe83128150dd49aaa7deb5493523309f0a9749c3c075730a6981851607455", size = 1627660, upload-time = "2026-04-02T04:50:36.5Z" },
-]
-
-[[package]]
-name = "dbus-next"
-version = "0.2.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/45/6a40fbe886d60a8c26f480e7d12535502b5ba123814b3b9a0b002ebca198/dbus_next-0.2.3.tar.gz", hash = "sha256:f4eae26909332ada528c0a3549dda8d4f088f9b365153952a408e28023a626a5", size = 71112, upload-time = "2021-07-25T22:11:28.398Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fc/c0a3f4c4eaa5a22fbef91713474666e13d0ea2a69c84532579490a9f2cc8/dbus_next-0.2.3-py3-none-any.whl", hash = "sha256:58948f9aff9db08316734c0be2a120f6dc502124d9642f55e90ac82ffb16a18b", size = 57885, upload-time = "2021-07-25T22:11:25.466Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Replace the dbus-next proxy helper with a direct dbus-fast Device1.Disconnect call and deterministically close its system-bus connection on every path.

Keep partially initialized clients and trainer machines reachable for cleanup, reserve the raw BlueZ disconnect for failed or InProgress Bleak operations, and detect trainer link loss so reconnects can proceed.

Add lifecycle regression tests covering bus failures, partial session setup, fallback behavior, trainer cleanup, and disconnect state changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device disconnect reliability and cleanup across Linux Bluetooth connections.
  * Added fallback disconnect handling when standard BLE disconnects fail.
  * Improved recovery from partially completed connection or setup attempts.
  * Fixed connection state updates when devices disconnect unexpectedly.

* **Tests**
  * Added coverage for disconnect failures, cleanup, fallback behavior, and connection state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->