### PR TITLE
trainer: Ignore stale notifications after disconnect

### DIFF
--- a/src/bleaksport/trainer.py
+++ b/src/bleaksport/trainer.py
@@ -374,9 +374,15 @@ class TrainerMux:
         logger.debug("TrainerMux: connecting and streaming")
 
         machine_type = self._provided_machine_type
+        machine: FitnessMachine | None = None
 
         def _on_ftms_event(event: Any) -> None:
             try:
+                # pyftms can deliver queued notifications after disconnect, or
+                # after a replacement machine has connected. Ignore callbacks
+                # that no longer belong to the mux's active machine.
+                if machine is None or self._machine is not machine:
+                    return
                 if getattr(event, "event_id", None) != "update":
                     return
                 data = dict(getattr(event, "event_data", {}) or {})

--- a/src/bleaksport/trainer.py
+++ b/src/bleaksport/trainer.py
@@ -381,7 +381,7 @@ class TrainerMux:
                 # pyftms can deliver queued notifications after disconnect, or
                 # after a replacement machine has connected. Ignore callbacks
                 # that no longer belong to the mux's active machine.
-                if machine is None or self._machine is not machine:
+                if machine is None or self._machine is not machine or not self.is_connected:
                     return
                 if getattr(event, "event_id", None) != "update":
                     return

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,7 +1,8 @@
-# ruff: noqa: ANN001, ANN201, ANN202, ANN204, ARG002, D101, D102, I001, PT009, PT027, SIM117, SLF001
+# ruff: noqa: ANN001, ANN002, ANN003, ANN201, ANN202, ANN204, ARG002, D101, D102, I001, PT009, PT027, SIM117, SLF001
 
 import asyncio
 import unittest
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 from bleak import BleakError
@@ -285,6 +286,30 @@ class TrainerLifecycleTests(unittest.IsolatedAsyncioTestCase):
         machine.disconnect_callback(machine)
         self.assertFalse(mux.is_connected)
         await mux._disconnect()
+
+    async def test_stale_machine_notifications_are_ignored_after_disconnect(self):
+        machine = _FakeMachine()
+        samples = []
+        captured_callback = None
+
+        def make_client(*_args, **kwargs):
+            nonlocal captured_callback
+            captured_callback = kwargs["on_ftms_event"]
+            return machine
+
+        mux = TrainerMux(addr=_Device(), machine_type=object(), on_sample=samples.append)
+        with patch("bleaksport.trainer.get_client", side_effect=make_client):
+            await mux._connect_and_stream()
+
+        await mux._disconnect()
+        captured_callback(
+            SimpleNamespace(
+                event_id="update",
+                event_data={"heart_rate": 99, "resistance_level": 19},
+            ),
+        )
+
+        self.assertEqual(samples, [])
 
 
 if __name__ == "__main__":

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -288,28 +288,40 @@ class TrainerLifecycleTests(unittest.IsolatedAsyncioTestCase):
         await mux._disconnect()
 
     async def test_stale_machine_notifications_are_ignored_after_disconnect(self):
-        machine = _FakeMachine()
+        machine_a = _FakeMachine()
+        machine_b = _FakeMachine()
         samples = []
-        captured_callback = None
+        captured_callbacks = []
+        machines = iter((machine_a, machine_b))
 
         def make_client(*_args, **kwargs):
-            nonlocal captured_callback
-            captured_callback = kwargs["on_ftms_event"]
-            return machine
+            captured_callbacks.append(kwargs["on_ftms_event"])
+            return next(machines)
 
         mux = TrainerMux(addr=_Device(), machine_type=object(), on_sample=samples.append)
         with patch("bleaksport.trainer.get_client", side_effect=make_client):
             await mux._connect_and_stream()
 
-        await mux._disconnect()
-        captured_callback(
-            SimpleNamespace(
+            event = SimpleNamespace(
                 event_id="update",
                 event_data={"heart_rate": 99, "resistance_level": 19},
-            ),
-        )
+            )
 
-        self.assertEqual(samples, [])
+            # The low-level disconnect callback clears lifecycle state before
+            # TrainerMux._disconnect() clears its machine reference.
+            machine_a.disconnect_callback(machine_a)
+            self.assertIs(mux._machine, machine_a)
+            captured_callbacks[0](event)
+            self.assertEqual(samples, [])
+
+            # A queued callback from the replaced machine must also be ignored.
+            await mux._connect_and_stream()
+            self.assertIs(mux._machine, machine_b)
+            self.assertIsNot(captured_callbacks[0], captured_callbacks[1])
+            captured_callbacks[0](event)
+            self.assertEqual(samples, [])
+
+        await mux._disconnect()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Discard queued FTMS callbacks when their machine is no longer the active TrainerMux connection. This prevents disconnected target getters from emitting repeated warnings and stops stale telemetry from reaching consumers after disconnect or replacement. Add a lifecycle regression test covering a late notification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale device notifications received after disconnection or reconnection from updating workout data.
  * Ensured outdated events no longer trigger sample callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->